### PR TITLE
Implement Toeplitz matrices

### DIFF
--- a/test/test_toeplitz.py
+++ b/test/test_toeplitz.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+from torch.testing import assert_allclose
+from scipy.linalg import toeplitz as np_toeplitz
+from torch_mir_eval.toeplitz import toeplitz, batch_toeplitz
+
+
+class TestToeplitz(unittest.TestCase):
+    def test_toeplitz_nor(self):
+        c = [1, 2, 3, 5, 4]
+        np_toep = np_toeplitz(c)
+        torch_toep = toeplitz(c)
+        assert_allclose(torch.from_numpy(np_toep), torch_toep)
+
+    def test_toeplitz(self):
+        c, r = [1, 2, 3], [4, 3, 1, 2]
+        np_toep = np_toeplitz(c, r=r)
+        torch_toep = toeplitz(c, r=r)
+        assert_allclose(torch.from_numpy(np_toep), torch_toep)
+
+    def test_batch_toeplitz_nor(self):
+        bc = torch.randn(3, 8)
+        indirect_toep = torch.stack(
+            [toeplitz(c) for c in bc],
+            dim=0
+        )
+        direct_toep = batch_toeplitz(bc)
+        assert_allclose(indirect_toep, direct_toep)
+
+    def test_batch_toeplitz(self):
+        bc = torch.randn(3, 8)
+        br = torch.randn(3, 4)
+        indirect_toep = torch.stack(
+            [toeplitz(c, r) for c, r in zip(bc, br)],
+            dim=0
+        )
+        direct_toep = batch_toeplitz(bc, br)
+        assert_allclose(indirect_toep, direct_toep)
+

--- a/torch_mir_eval/toeplitz.py
+++ b/torch_mir_eval/toeplitz.py
@@ -1,0 +1,85 @@
+import torch
+
+
+def toeplitz(c, r=None):
+    """
+    Construct a Toeplitz matrix.
+
+    The Toeplitz matrix has constant diagonals, with c as its first column
+    and r as its first row. If r is not given, ``r == c`` is
+    assumed.
+    Inspired from scipy.linalg.toeplitz
+
+
+    Parameters
+    ----------
+    c : tensor_like
+        First column of the matrix.  Whatever the actual shape of `c`, it
+        will be converted to a 1-D array.
+    r : tensor_like, optional
+        First row of the matrix. If None, ``r = c`` is assumed.
+        r[0] is ignored; the first row of the returned matrix is
+        ``[c[0], r[1:]]``.  Whatever the actual shape of `r`, it will be
+        converted to a 1-D array.
+
+    Returns
+    -------
+    A : (len(c), len(r)) torch.Tensor
+        The Toeplitz matrix. Dtype is the same as ``(c[0] + r[0]).dtype``.
+
+    Examples
+    --------
+    >>> toeplitz([1,2,3], [1,4,5,6])
+    tensor([[1, 4, 5, 6],
+           [2, 1, 4, 5],
+           [3, 2, 1, 4]])
+
+    """
+    c = torch.as_tensor(c).view(-1)
+    r = c if r is None else torch.as_tensor(r).view(-1)
+    vals = torch.cat([torch.flip(c, dims=(0,)), r[1:]])
+    toep = torch.stack([
+        torch.roll(vals, shifts=i, dims=0)[-len(r):] for i in range(len(c))
+    ])
+    return toep
+
+
+def batch_toeplitz(c, r=None):
+    """
+    Construct a batch Toeplitz matrix.
+
+    The Toeplitz matrix has constant diagonals, with c as its first column
+    and r as its first row. If r is not given, ``r == c`` is
+    assumed.
+    Inspired from scipy.linalg.toeplitz
+
+    Parameters
+    ----------
+    c : tensor_like
+        First column of the matrix.  Whatever the actual shape of `c`, it
+        will be converted to a batched 1-D array.
+    r : tensor_like, optional
+        First row of the matrix. If None, ``r = c`` is assumed.
+        r[0] is ignored; the first row of the returned matrix is
+        ``[c[:, 0], r[:, 1:]]``.  Whatever the actual shape of `r`, it will be
+        converted to a batched 1-D array.
+
+    Returns
+    -------
+    A : (batch, len(c), len(r)) torch.Tensor
+        The Toeplitz matrix. Dtype is the same as ``(c[0] + r[0]).dtype``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> batch_toeplitz(torch.randn(2, 3), torch.randn(2, 4))
+    """
+    c = torch.as_tensor(c).view(c.shape[0], -1)
+    r = c if r is None else torch.as_tensor(r).view(r.shape[0], -1)
+    assert c.shape[0] == r.shape[0], "Batch dimension shoudl agree between r and c."
+
+    vals = torch.cat([torch.flip(c, dims=(1,)), r[:, 1:]], dim=1)
+    toep = torch.stack([
+        torch.roll(vals, shifts=i, dims=1)[:, -r.shape[1]:] for i in range(c.shape[1])
+    ], dim=1)
+    return toep


### PR DESCRIPTION
### About the PR

- [x] Implement Toeplitz matrices in `torch`
- [x] Implement batch Toeplitz matrices in `torch`
- [x] Unit test against `scipy`
- [ ] Use it in `separation.py`
